### PR TITLE
Support Laravel 5.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # Despark's igniCMS
 
-**igniCMS** is an administrative interface builder for Laravel 5.4|5.5
+**igniCMS** is an administrative interface builder for Laravel 5.4|5.5|5.6
 
 ## Prerequisites
 
@@ -20,7 +20,7 @@
 
 1. Run `composer require despark/igni-core`.
 
-2. Add igniCMS service providers before the _application service providers_ in the `config/app.php`, as shown below **(Optional for Laravel 5.5)** 
+2. Add igniCMS service providers before the _application service providers_ in the `config/app.php`, as shown below **(Optional for Laravel 5.5+)** 
 
   _Example_
 

--- a/composer.json
+++ b/composer.json
@@ -29,23 +29,24 @@
     "type": "library",
     "require": {
         "php": ">=5.6.4",
-        "laravel/framework": "5.4.*|5.5.*",
+        "laravel/framework": "5.6.*",
         "laravelcollective/html": "~5.1",
         "flowjs/flow-php-server": "^1.0",
         "intervention/image": "^2.3",
         "cviebrock/eloquent-sluggable": "^4.1",
-        "rutorika/sortable": "^2.3",
+        "rutorika/sortable": ">=2.3",
         "doctrine/dbal": "^2.5",
         "yajra/laravel-datatables-oracle": "~8.0",
-        "spatie/laravel-permission": "^1.11",
+        "spatie/laravel-permission": ">=1.11",
         "despark/laravel-db-i18n": "v1.x"
     },
     "require-dev": {
         "barryvdh/laravel-ide-helper": "^2.1",
-        "graham-campbell/testbench": "^3.2",
+        "graham-campbell/testbench": "^5.0",
         "fzaninotto/faker": "~1.4",
-        "mockery/mockery": "0.9.*",
-        "phpunit/phpunit": "~5.7"
+        "mockery/mockery": "^1.0",
+        "phpunit/phpunit": "^7.0",
+        "sllh/composer-versions-check": "^2.0.3"
     },
     "autoload": {
         "classmap": [],

--- a/src/Console/Commands/Page/model.stub
+++ b/src/Console/Commands/Page/model.stub
@@ -23,14 +23,14 @@ class Page extends AdminModel implements UploadImageInterface
     protected $rules = [
         'title' => 'required|max:100|unique::table_name,title',
         'meta_description' => 'max:255',
-        'slug' => 'max:200|unique::full_table_name,slug',
+        'slug' => 'max:200|unique::table_name,slug',
         'content' => 'required',
         'meta_image' => 'image|max:5000|required',
     ];
 
     protected $rulesUpdate = [
         'title' => 'required|max:100|unique::table_name,title,{id},id',
-        'slug' => 'max:200|unique::full_table_name,slug,{id},id',
+        'slug' => 'max:200|unique::table_name,slug,{id},id',
         'meta_image' => 'image|max:5000',
     ];
 

--- a/src/Console/Commands/PagesResourceCommand.php
+++ b/src/Console/Commands/PagesResourceCommand.php
@@ -165,6 +165,6 @@ class PagesResourceCommand extends Command
             'updated_at' => date('Y-m-d H:i:s'),
         ];
 
-        \DB::table(str_plural($this->fullTableName))->insert($page);
+        \DB::table(str_plural($this->tableName))->insert($page);
     }
 }

--- a/src/Contracts/RequestContract.php
+++ b/src/Contracts/RequestContract.php
@@ -7,8 +7,6 @@ namespace Despark\Cms\Contracts;
 interface RequestContract
 {
 
-    public function validate();
-
     public function rules();
 
     public function authorize();

--- a/src/Http/Controllers/EntityController.php
+++ b/src/Http/Controllers/EntityController.php
@@ -31,7 +31,7 @@ class EntityController extends AdminController
         $input = $request->all();
 
         if ($this->model instanceof Translatable) {
-            $this->model->setActiveLocale($input['locale']);
+            $this->model->setActiveLocale($request->get('locale', $this->model->getDefaultLocale()));
         }
         $record = $this->model->create($input);
         if (method_exists($record, 'getManyToManyFields')) {
@@ -69,7 +69,7 @@ class EntityController extends AdminController
         $input = $request->all();
 
         if ($this->model instanceof Translatable) {
-            $this->model->setActiveLocale($input['locale']);
+            $this->model->setActiveLocale($request->get('locale', $this->model->getDefaultLocale()));
         }
 
         $record = $this->model->findOrFail($id);

--- a/src/Http/Requests/AdminFormRequest.php
+++ b/src/Http/Requests/AdminFormRequest.php
@@ -4,11 +4,12 @@ namespace Despark\Cms\Http\Requests;
 
 use Despark\Cms\Admin\Traits\AdminValidateTrait;
 use Despark\Cms\Contracts\RequestContract;
+use Illuminate\Contracts\Validation\ValidatesWhenResolved;
 
 /**
  * Class ProjectRequest.
  */
-class AdminFormRequest extends Request implements RequestContract
+class AdminFormRequest extends Request implements RequestContract, ValidatesWhenResolved
 {
     use AdminValidateTrait;
 


### PR DESCRIPTION
Add supporting changes to Laravel 5.6 
Small fixes for:
- wrong pages model generation
-  interface support for validation requests
- fix translatable update/create default locale